### PR TITLE
Add some logging infrastructure to compbot branch

### DIFF
--- a/2025Reefscape/build.gradle
+++ b/2025Reefscape/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2025.3.1"
+    id "edu.wpi.first.GradleRIO" version "2025.3.2"
 }
 
 java {

--- a/2025Reefscape/src/main/java/frc/robot/Constants.java
+++ b/2025Reefscape/src/main/java/frc/robot/Constants.java
@@ -338,5 +338,15 @@ public final class Constants {
   }
 
   public static final double ROBOT_PERIOD = 0;
+
+  public static final class Logging {
+    public static final boolean enabled = true;         // Setting to disabled with make most log calls do nothing.
+
+    public static final boolean captureDS = true;       // Include DriverStation logging such as joystick inputs?
+    public static final boolean captureNT = false;      // Include NetworkTable entries?
+    public static final boolean captureConsole = false; // Include console messages (println statements)
+    public static final boolean capturePDH = false;     // Include current information from the PDP/PDH? Capture extras must be true.
+    public static final boolean captureExtras = false;  // Capture "extras" like CAN utilization
+  }
   
 }

--- a/2025Reefscape/src/main/java/frc/robot/Robot.java
+++ b/2025Reefscape/src/main/java/frc/robot/Robot.java
@@ -6,6 +6,7 @@ package frc.robot;
 
 import com.ctre.phoenix6.SignalLogger;
 
+import dev.doglog.DogLog;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.TimedRobot;
@@ -84,6 +85,15 @@ public class Robot extends TimedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
+
+    // Log a bunch of stuff so we can try to figure out what's happening in the auto -> teleop transition
+    var drivetrain = m_robotContainer.drivetrain;
+    var drivetrainState = drivetrain.getState();
+    DogLog.log("TeleopInit/drivetrainPose", drivetrainState.Pose);
+    DogLog.log("TeleopInit/drivetrainRawHeading", drivetrainState.RawHeading);
+    DogLog.log("TeleopInit/pigeonYas", drivetrain.getPigeon2().getRotation2d());
+    DogLog.log("TeleopInit/operatorForwardDirection", drivetrain.getOperatorForwardDirection());
+
    var rotationFlipped = m_robotContainer.drivetrain.getState().Pose.getRotation().plus(Rotation2d.k180deg);
     m_robotContainer.drivetrain.resetRotation(rotationFlipped);
 

--- a/2025Reefscape/src/main/java/frc/robot/RobotContainer.java
+++ b/2025Reefscape/src/main/java/frc/robot/RobotContainer.java
@@ -6,11 +6,15 @@ package frc.robot;
 
 import static edu.wpi.first.units.Units.*;
 
+import dev.doglog.DogLog;
+import dev.doglog.DogLogOptions;
+
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
 import com.ctre.phoenix6.swerve.SwerveRequest;
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.auto.NamedCommands;
 
+import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
@@ -87,6 +91,8 @@ public class RobotContainer {
     public ShuffleboardTab limelightTab = Shuffleboard.getTab("Limelight");
 
     public RobotContainer() {
+        configureLogging();
+
         NamedCommands.registerCommand("Remove Algae L2", new SequentialCommandGroup(
             new MoveElevator(elevator, Constants.Elevator.ALGAE_L2_HEIGHT, algaeMechanism),
             new ParallelRaceGroup(new MoveAlgaePivot(algaeMechanism, Constants.Algae.ALGAE_DOWN), new RunAlgaeIntake(intake, -0.7)).withTimeout(0.75),
@@ -217,6 +223,21 @@ public class RobotContainer {
         coralIntake.configDashboard(matchTab);
         
         //algaeMechanism.setReltoAbs();
+    }
+
+    private void configureLogging() {
+        var logOptions = new DogLogOptions()
+            .withCaptureDs(Constants.Logging.captureDS)
+            .withCaptureNt(Constants.Logging.captureNT)
+            .withLogExtras(Constants.Logging.captureExtras)
+            .withCaptureConsole(Constants.Logging.captureConsole);
+
+        if (Constants.Logging.capturePDH) {
+            DogLog.setPdh(new PowerDistribution());
+        }
+        
+        DogLog.setOptions(logOptions);
+        DogLog.setEnabled(Constants.Logging.enabled);
     }
     
     private void configureBindings() {

--- a/2025Reefscape/src/main/java/frc/robot/commands/AlignBranch.java
+++ b/2025Reefscape/src/main/java/frc/robot/commands/AlignBranch.java
@@ -6,6 +6,7 @@ package frc.robot.commands;
 
 import com.ctre.phoenix6.swerve.SwerveRequest;
 
+import dev.doglog.DogLog;
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -50,14 +51,23 @@ public class AlignBranch extends Command {
      */
     @Override
     public void execute() {
+      // It's poor practice to check the same value more than once because it could change between checks. But I'm trying to
+      // minimize code changes.
+      boolean canSeeTag = vision.getAlignmentCheck() != 0.0; // Also poor that this is a double, but that's what Limelight does...
+      DogLog.log("AlignBranch/seesTag", canSeeTag);
+
+      // This should be refactored. Have the branches set chassis speeds, and then set the control at the end.
       if (vision.getAlignmentCheck() == 0) {
         ChassisSpeeds chassisSpeeds = new ChassisSpeeds(0, 0.0, 0.0);   
+        DogLog.log("AlignBranch/appliedChassisSpeeds", chassisSpeeds);
         drivetrain.setControl(request.withSpeeds(chassisSpeeds));
       } else {
         alignmentOffset = vision.getAlignmentOffset();
+        DogLog.log("AlignBranch/offset", alignmentOffset);
         if (alignmentOffset >= 1.0){ //3.0
           xSpeed = -Constants.Vision.ALIGNMENT_SPEED;
           chassisSpeeds = new ChassisSpeeds(0, xSpeed, 0.0);
+          DogLog.log("AlignBranch/appliedChassisSpeeds", chassisSpeeds);
           drivetrain.setControl(request.withSpeeds(chassisSpeeds));
           vision.setInRangeFalse();
         } else if (alignmentOffset < 1.0 && alignmentOffset >= -1.0) { //0.0 //3.0 and -1.0
@@ -65,6 +75,7 @@ public class AlignBranch extends Command {
         } else {
           xSpeed = Constants.Vision.ALIGNMENT_SPEED;
           chassisSpeeds = new ChassisSpeeds(0.0, xSpeed, 0.0);
+          DogLog.log("AlignBranch/appliedChassisSpeeds", chassisSpeeds);
           drivetrain.setControl(request.withSpeeds(chassisSpeeds));
           vision.setInRangeFalse();
         }

--- a/2025Reefscape/src/main/java/frc/robot/commands/ZAlign.java
+++ b/2025Reefscape/src/main/java/frc/robot/commands/ZAlign.java
@@ -6,6 +6,7 @@ package frc.robot.commands;
 
 import com.ctre.phoenix6.swerve.SwerveRequest;
 
+import dev.doglog.DogLog;
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -53,14 +54,23 @@ public class ZAlign extends Command {
    */
   @Override
   public void execute() {
+    // It's poor practice to check the same value more than once because it could change between checks. But I'm trying to
+    // minimize code changes.
+    boolean canSeeTag = vision.getAlignmentCheck() != 0.0; // Also poor that this is a double, but that's what Limelight does...
+    DogLog.log("ZAlign/seesTag", canSeeTag);
+
+    // This should be refactored. Have the branches set chassis speeds, and then set the control at the end.
     if (vision.getAlignmentCheck() == 0) {
       ChassisSpeeds chassisSpeeds = new ChassisSpeeds(0, 0.0, 0.0);   
+      DogLog.log("ZAlign/appliedChassisSpeeds", chassisSpeeds);
       drivetrain.setControl(request.withSpeeds(chassisSpeeds));
     } else {
       alignmentOffset = vision.getZOffsets();
+      DogLog.log("ZAlign/offset", alignmentOffset);
       if (alignmentOffset >= 3.0){
         zSpeed = Constants.Vision.ALIGNMENT_SPEED;
         chassisSpeeds = new ChassisSpeeds(zSpeed, 0.0, 0.0);
+        DogLog.log("ZAlign/appliedChassisSpeeds", chassisSpeeds);
         drivetrain.setControl(request.withSpeeds(chassisSpeeds));
         vision.setInRangeFalse();
       } else if (alignmentOffset < 3.0 && alignmentOffset >= 0.0) {
@@ -68,6 +78,7 @@ public class ZAlign extends Command {
       } else {
         zSpeed = -Constants.Vision.ALIGNMENT_SPEED;
         chassisSpeeds = new ChassisSpeeds(zSpeed, 0.0, 0.0);
+        DogLog.log("ZAlign/appliedChassisSpeeds", chassisSpeeds);
         drivetrain.setControl(request.withSpeeds(chassisSpeeds));
         vision.setInRangeFalse();
       }
@@ -78,6 +89,7 @@ public class ZAlign extends Command {
   @Override
   public void end(boolean interrupted) {
     ChassisSpeeds chassisSpeeds = new ChassisSpeeds(0, 0.0, 0.0);   
+    DogLog.log("ZAlign/appliedChassisSpeeds", chassisSpeeds);
     drivetrain.setControl(request.withSpeeds(chassisSpeeds));
   }
 

--- a/2025Reefscape/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/2025Reefscape/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -14,6 +14,7 @@ import com.pathplanner.lib.config.PIDConstants;
 import com.pathplanner.lib.config.RobotConfig;
 import com.pathplanner.lib.controllers.PPHolonomicDriveController;
 
+import dev.doglog.DogLog;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -280,10 +281,22 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
     }
     
     public void updateOdometryPoseEstimator(){
+        var drivetrainState = getState();
+        Rotation2d drivetrainRotation = getRotation2d();
+        Rotation2d pigeonYaw = getPigeon2().getRotation2d();
+        Rotation2d rawHeading = drivetrainState.RawHeading;
+        Pose2d robotPose = drivetrainState.Pose;
+
         // Tell Limelight what our current orientation is
         LimelightHelpers.SetRobotOrientation("limelight-santos", getRotation2d().getDegrees(), 0, 0, 0, 0, 0);
         LimelightHelpers.PoseEstimate mt2 = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2("limelight-santos");
         boolean doRejectUpdate = false;
+
+        DogLog.log("DrivetrainUpdate/drivetrainRotation", drivetrainRotation);
+        DogLog.log("DrivetrainUpdate/pigeonYaw", pigeonYaw);
+        DogLog.log("DrivetrainUpdate/tagCount", mt2 != null ? mt2.tagCount : 0);
+        DogLog.log("DrivetrainUpdate/drivetrainRawHeading", rawHeading);
+        DogLog.log("DrivetrainUpdate/drivetrainPose", robotPose);
 
         // If we don't see any tags, the pose can't be good
         if(mt2.tagCount == 0) {
@@ -291,10 +304,13 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         }
 
         if(!doRejectUpdate) {
+            DogLog.log("DrivetrainUpdate/mt2Pose", mt2.pose);
             setVisionMeasurementStdDevs(VecBuilder.fill(.7,.7,9999999));
             addVisionMeasurement(mt2.pose, mt2.timestampSeconds);
             limelightPublisher.set(mt2.pose);
         }
+
+        DogLog.log("DrivetrainUpdate/acceptedUpdate", !doRejectUpdate);
     }
 
     //************************ new limelight method for drive */
@@ -341,7 +357,9 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
             });
         }
 
-        m_field.setRobotPose(getState().Pose);
+        Pose2d pose = getState().Pose;
+        m_field.setRobotPose(pose);
+        DogLog.log("Drivetrain/Pose", pose);
     }
 
     private void startSimThread() {

--- a/2025Reefscape/src/main/java/frc/robot/subsystems/VisionUpdate.java
+++ b/2025Reefscape/src/main/java/frc/robot/subsystems/VisionUpdate.java
@@ -6,9 +6,10 @@ package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.LimelightHelpers;
-
+import dev.doglog.DogLog;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.networktables.IntegerPublisher;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
@@ -38,9 +39,21 @@ public class VisionUpdate extends SubsystemBase {
   @Override
   public void periodic() {
     // Tell Limelight what our current orientation is
-    LimelightHelpers.SetRobotOrientation("limelight-santos", drivetrain.getRotation2d().getDegrees(), 0, 0, 0, 0, 0);
+    var drivetrainState = drivetrain.getState();
+    Rotation2d drivetrainRotation = drivetrain.getRotation2d();
+    Rotation2d pigeonYaw = drivetrain.getPigeon2().getRotation2d();
+    Rotation2d rawHeading = drivetrainState.RawHeading;
+    Pose2d robotPose = drivetrainState.Pose;
+
+    LimelightHelpers.SetRobotOrientation("limelight-santos", drivetrainRotation.getDegrees(), 0, 0, 0, 0, 0);
     LimelightHelpers.PoseEstimate mt2 = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2("limelight-santos");
     boolean doRejectUpdate = false;
+
+    DogLog.log("VisionUpdate/drivetrainRotation", drivetrainRotation);
+    DogLog.log("VisionUpdate/pigeonYaw", pigeonYaw);
+    DogLog.log("VisionUpdate/tagCount", mt2 != null ? mt2.tagCount : 0);
+    DogLog.log("VisionUpdate/drivetrainRawHeading", rawHeading);
+    DogLog.log("VisionUpdate/drivetrainPose", robotPose);
 
     // If we don't see any tags, the pose can't be good
     if(mt2.tagCount == 0) {
@@ -49,11 +62,14 @@ public class VisionUpdate extends SubsystemBase {
     if(!doRejectUpdate) {
       drivetrain.setVisionMeasurementStdDevs(VecBuilder.fill(.7,.7,9999999));
       drivetrain.addVisionMeasurement(mt2.pose, mt2.timestampSeconds);
+      DogLog.log("VisionUpdate/mt2Pose", mt2.pose);
       limelightPublisher.set(mt2.pose);
       updatePublisher.set(++odometryUpdates);
     } else {
       discardPublisher.set(++odometryDiscards);
     }
+
+    DogLog.log("VisionUpdate/acceptedUpdate", !doRejectUpdate);
   }
 
     // //This method will be called once per scheduler run

--- a/2025Reefscape/vendordeps/DogLog.json
+++ b/2025Reefscape/vendordeps/DogLog.json
@@ -1,0 +1,20 @@
+{
+    "javaDependencies": [
+        {
+            "groupId": "com.github.jonahsnider",
+            "artifactId": "doglog",
+            "version": "2025.4.0"
+        }
+    ],
+    "fileName": "DogLog.json",
+    "frcYear": "2025",
+    "jsonUrl": "https://doglog.dev/vendordep.json",
+    "name": "DogLog",
+    "jniDependencies": [],
+    "mavenUrls": [
+        "https://jitpack.io"
+    ],
+    "cppDependencies": [],
+    "version": "2025.4.0",
+    "uuid": "65592ce1-2251-4a31-8e4b-2df20dacebe4"
+}


### PR DESCRIPTION
Add a logging configuration section to constants. As set right now, it enables explicit logging statements, and captures driver station input, but does not capture additional pieces. You can optionally turn on PDH current logging, extras like CAN utilization and battery voltage, or even all of NetworkTables (which is likely expensive). Added logging statements around the auto -> teleop transition. Added logging into various Vision alignment and odometry update paths.
