### PR TITLE
Mr. Santos' localization fixes

### DIFF
--- a/2025Reefscape/src/main/java/frc/robot/RobotContainer.java
+++ b/2025Reefscape/src/main/java/frc/robot/RobotContainer.java
@@ -72,7 +72,7 @@ public class RobotContainer {
     public final static CommandSwerveDrivetrain drivetrain = TunerConstants.createDrivetrain();
 
     public static final Vision vision = new Vision(); 
-    public static final Vision odometryVision = new Vision();
+    // public static final Vision odometryVision = new Vision(); // No need to create a second one of these
     // public static final VisionUpdate update = new VisionUpdate(drivetrain);
 
     private final SlewRateLimiter m_xspeedLimiter = new SlewRateLimiter(3);

--- a/2025Reefscape/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/2025Reefscape/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -281,7 +281,9 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
     
     public void updateOdometryPoseEstimator(){
         // Tell Limelight what our current orientation is
-        LimelightHelpers.SetRobotOrientation("limelight-santos", getRotation2d().getDegrees(), 0, 0, 0, 0, 0);
+        var driveState = getState();
+        Rotation2d heading = driveState.Pose.getRotation();
+        LimelightHelpers.SetRobotOrientation("limelight-santos", heading.getDegrees(), 0, 0, 0, 0, 0);
         LimelightHelpers.PoseEstimate mt2 = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2("limelight-santos");
         boolean doRejectUpdate = false;
 
@@ -292,7 +294,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
 
         if(!doRejectUpdate) {
             setVisionMeasurementStdDevs(VecBuilder.fill(.7,.7,9999999));
-            addVisionMeasurement(mt2.pose, mt2.timestampSeconds);
+            addVisionMeasurement(mt2.pose, Utils.fpgaToCurrentTime(mt2.timestampSeconds));
             limelightPublisher.set(mt2.pose);
         }
     }
@@ -304,9 +306,10 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         var chassisSpeeds = new ChassisSpeeds(xSpeed, ySpeed, rot);
         
         if (fieldRelative) {
-        chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot, getRotation2d());
+            Rotation2d fieldHeading = getState().Pose.getRotation();
+            chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot, fieldHeading);
         } else {
-        chassisSpeeds = new ChassisSpeeds(xSpeed, ySpeed, rot);
+            chassisSpeeds = new ChassisSpeeds(xSpeed, ySpeed, rot);
         }
 
         //discretize -- smooths movement, prevents sudden acceleration        
@@ -357,10 +360,6 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
             updateSimState(deltaTime, RobotController.getBatteryVoltage());
         });
         m_simNotifier.startPeriodic(kSimLoopPeriod);
-    }
-
-    public Rotation2d getRotation2d() {
-        return gyro.getRotation2d();
     }
 
     public void configDashboard(ShuffleboardTab tab) {

--- a/2025Reefscape/src/main/java/frc/robot/subsystems/VisionUpdate.java
+++ b/2025Reefscape/src/main/java/frc/robot/subsystems/VisionUpdate.java
@@ -7,8 +7,11 @@ package frc.robot.subsystems;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.LimelightHelpers;
 
+import com.ctre.phoenix6.Utils;
+
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.networktables.IntegerPublisher;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
@@ -38,7 +41,9 @@ public class VisionUpdate extends SubsystemBase {
   @Override
   public void periodic() {
     // Tell Limelight what our current orientation is
-    LimelightHelpers.SetRobotOrientation("limelight-santos", drivetrain.getRotation2d().getDegrees(), 0, 0, 0, 0, 0);
+    var driveState = drivetrain.getState();
+    Rotation2d heading = driveState.Pose.getRotation();
+    LimelightHelpers.SetRobotOrientation("limelight-santos", heading.getDegrees(), 0, 0, 0, 0, 0);
     LimelightHelpers.PoseEstimate mt2 = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2("limelight-santos");
     boolean doRejectUpdate = false;
 
@@ -48,7 +53,7 @@ public class VisionUpdate extends SubsystemBase {
     }
     if(!doRejectUpdate) {
       drivetrain.setVisionMeasurementStdDevs(VecBuilder.fill(.7,.7,9999999));
-      drivetrain.addVisionMeasurement(mt2.pose, mt2.timestampSeconds);
+      drivetrain.addVisionMeasurement(mt2.pose, Utils.fpgaToCurrentTime(mt2.timestampSeconds));
       limelightPublisher.set(mt2.pose);
       updatePublisher.set(++odometryUpdates);
     } else {


### PR DESCRIPTION
1. When you "reset the gyro" with CTRE, it's not really resetting the gyro. CTRE maintains an offset, so to get the field-relative heading, you need to check the drivetrain's pose, and get the rotation from there. This mostly affects the value we're passing into Limelight for MT2.
2. WPI's pose estimator and CTRE's drivetrain have add vision measurement methods with the exact same signature, so you'd assume they take the same arguments, right? It turns out that WPI's expects a double in the timebase of the FPGA, but CTRE's expects a ddouble in the time base used by getCurrentTime(). So which does Limelight use? Well, they use NetworkTables, and that uses FPGA time (when run on a Rio). So before we can pass the value into CTRE, we need to convert the timestamp from LL/NT into a corresponding CurrentTime-based value. I think you may have had that previously, but I didn't know that was required...
3. We create two Vision() subsystems for no apparently reason. That doesn't really cause any harm, but periodic does do some work with NetworkTables, so better to avoid that.